### PR TITLE
Reconciler now selects random nodes if spec.targetNode not specified

### DIFF
--- a/config/samples/full-cluster.yaml
+++ b/config/samples/full-cluster.yaml
@@ -148,7 +148,7 @@ spec:
       name: testing-control-plane
       namespace: default
   replicas: 3
-  version: v1.28.2
+  version: v1.28.1
 ---
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
@@ -175,7 +175,7 @@ spec:
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
         kind: ProxmoxMachineTemplate
         name: testing-md-0
-      version: v1.28.2
+      version: v1.28.1
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: ProxmoxMachineTemplate
@@ -185,7 +185,6 @@ metadata:
 spec:
   template:
     spec:
-      targetNode: aphrodite
       template: "VM 9001"
       resources:
         memory: 4096
@@ -218,7 +217,6 @@ metadata:
 spec:
   template:
     spec:
-      targetNode: aphrodite
       template: "VM 9001"
       resources:
         memory: 4096

--- a/internal/machine/node_selector.go
+++ b/internal/machine/node_selector.go
@@ -1,0 +1,41 @@
+package machine
+
+import (
+	infrastructurev1alpha1 "github.com/launchboxio/cluster-api-provider-proxmox/api/v1alpha1"
+	"github.com/luthermonson/go-proxmox"
+	"math/rand"
+	"time"
+)
+
+type Selector interface {
+	Select(nodes proxmox.NodeStatuses) (*proxmox.NodeStatus, error)
+}
+
+// TODO: Eventually this will use a strategy for node selection
+func (m *Machine) selectNode(selector Selector) (*proxmox.NodeStatus, error) {
+	nodes, err := m.ProxmoxClient.Nodes()
+	if err != nil {
+		return nil, err
+	}
+	filteredNodes := filterNodes(nodes, m.ProxmoxMachine)
+	if selector == nil {
+		selector = &RandomNodeGroupSelector{}
+	}
+
+	return selector.Select(filteredNodes)
+}
+
+// TODO: This is just a stub function to further filter nodes
+// to be filled out with a later update
+// filterNodes removes any nodes from the list that don't have
+// available CPU, memory, or disk
+func filterNodes(nodes proxmox.NodeStatuses, machine *infrastructurev1alpha1.ProxmoxMachine) proxmox.NodeStatuses {
+	return nodes
+}
+
+type RandomNodeGroupSelector struct{}
+
+func (rng *RandomNodeGroupSelector) Select(nodes proxmox.NodeStatuses) (*proxmox.NodeStatus, error) {
+	rand.Seed(time.Now().Unix())
+	return nodes[rand.Intn(len(nodes))], nil
+}

--- a/internal/machine/node_selector.go
+++ b/internal/machine/node_selector.go
@@ -27,6 +27,7 @@ func (m *Machine) selectNode(selector Selector) (*proxmox.NodeStatus, error) {
 
 // TODO: This is just a stub function to further filter nodes
 // to be filled out with a later update
+// Tracked by: https://github.com/launchboxio/cluster-api-provider-proxmox/issues/7
 // filterNodes removes any nodes from the list that don't have
 // available CPU, memory, or disk
 func filterNodes(nodes proxmox.NodeStatuses, machine *infrastructurev1alpha1.ProxmoxMachine) proxmox.NodeStatuses {

--- a/internal/machine/reconciler.go
+++ b/internal/machine/reconciler.go
@@ -212,9 +212,15 @@ func (m *Machine) reconcileCreate(ctx context.Context, req ctrl.Request) (ctrl.R
 			return ctrl.Result{}, err
 		}
 
-		if m.ProxmoxMachine.Spec.TargetNode != "" && vm.Node != m.ProxmoxMachine.Spec.TargetNode {
-			m.Logger.Info(fmt.Sprintf("Moving VM to node %s", m.ProxmoxMachine.Spec.TargetNode))
-			task, err := vm.Migrate(m.ProxmoxMachine.Spec.TargetNode, "")
+		node, err := m.selectNode(nil)
+		if err != nil {
+			m.Logger.Error(err, "Failed selecting node for VM")
+			return ctrl.Result{}, err
+		}
+
+		if vm.Node != node.Node {
+			m.Logger.Info(fmt.Sprintf("Moving VM to node %s", node.Node))
+			task, err := vm.Migrate(node.Node, "")
 			if err != nil {
 				return ctrl.Result{}, err
 			}


### PR DESCRIPTION
Closes #6 